### PR TITLE
feat: add surveys page for youth and companies in dashboard

### DIFF
--- a/backend/app/Http/Controllers/Dashboard/CompanyFormController.php
+++ b/backend/app/Http/Controllers/Dashboard/CompanyFormController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers\Dashboard;
+
+use App\Http\Controllers\Controller;
+use App\Models\CompanyForm;
+use Illuminate\Http\Request;
+
+class CompanyFormController extends Controller
+{
+    public function index()
+    {
+        $companyForms = CompanyForm::orderBy('created_at', 'desc')->paginate(9);
+        return view('dashboard.company-surveys.index', compact('companyForms'));
+    }
+}

--- a/backend/app/Http/Controllers/Dashboard/YouthFormController.php
+++ b/backend/app/Http/Controllers/Dashboard/YouthFormController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers\Dashboard;
+
+use App\Http\Controllers\Controller;
+use App\Models\YouthForm;
+use Illuminate\Http\Request;
+
+class YouthFormController extends Controller
+{
+    public function index()
+    {
+        $youthForms = YouthForm::orderBy('created_at', 'desc')->paginate(9);
+        return view('dashboard.youth-surveys.index', compact('youthForms'));
+    }
+}

--- a/backend/app/Http/Controllers/api/CompanyFormController.php
+++ b/backend/app/Http/Controllers/api/CompanyFormController.php
@@ -51,15 +51,15 @@ class CompanyFormController extends Controller
      */
     public function index()
     {
-        $companyForms = CompanyForm::all();
+        // $companyForms = CompanyForm::all();
 
-        // Decode JSON fields for readability
-        $companyForms->transform(function ($form) {
-            $form->skills = json_decode($form->skills, true);
-            $form->remote_hiring_preferences = json_decode($form->remote_hiring_preferences, true);
-            return $form;
-        });
+        // // Decode JSON fields for readability
+        // $companyForms->transform(function ($form) {
+        //     $form->skills = json_decode($form->skills, true);
+        //     $form->remote_hiring_preferences = json_decode($form->remote_hiring_preferences, true);
+        //     return $form;
+        // });
 
-        return response()->json($companyForms);
+        // return response()->json($companyForms);
     }
 }

--- a/backend/resources/views/components/common/content-container.blade.php
+++ b/backend/resources/views/components/common/content-container.blade.php
@@ -1,0 +1,4 @@
+<div class="bg-white shadow rounded-2xl p-4 mt-60 max-h-screen w-full overflow-auto">
+    <h2 class="text-xs border-b border-gray-100 pb-3 font-bold text-[#21255C] mb-4">{{ $title }}</h2> <!-- Title passed as a prop -->
+    {{ $slot }} 
+</div>

--- a/backend/resources/views/components/common/header.blade.php
+++ b/backend/resources/views/components/common/header.blade.php
@@ -1,0 +1,5 @@
+<header class="bg-white shadow py-5 px-3 sm:py-8 sm:px-6 rounded-2xl relative overflow-hidden">
+    <h1 class="text-sm text-[#21255C] font-bold relative w-fit after:content-[''] after:absolute after:w-[calc(100%+2.5rem)] after:h-12 after:bg-blue-500/20 after:rounded-tl-full after:rounded-bl-full after:right-[-24px] after:top-1/2 after:-translate-y-1/2">
+        {{ $title }} 
+    </h1>
+</header>

--- a/backend/resources/views/components/layout.blade.php
+++ b/backend/resources/views/components/layout.blade.php
@@ -23,10 +23,10 @@
 
             {{--------- Start Main Content ------------------}}
             <div id="main-content"
-                class="flex-1 gap-4 flex flex-col items-center transition-all duration-300 ease-in-out w-full">
+                class="flex-1 gap-2 flex flex-col items-center transition-all duration-300 ease-in-out w-full">
                 {{--------- NavBar ------------------}}
                 <x-layouts.navbar />
-                <main class="p-6 space-y-6 overflow-y-auto overflow-x-hidden">
+                <main class="px-2 pb-6 w-full space-y-2 overflow-y-auto overflow-x-hidden">
                     {{ $slot }}
                 </main>
             </div>

--- a/backend/resources/views/components/layouts/sidebar-link.blade.php
+++ b/backend/resources/views/components/layouts/sidebar-link.blade.php
@@ -2,120 +2,117 @@
 
 @if(empty($children))
 
-    <!-- Only For Logout -->
-    @if($icon == "logout")
-        <form action="/logout" method="POST">
-            @csrf
-            <div>
-              <button
-              type="submit"
-              class=" flex items-center px-4 py-3 rounded-xl transition-all duration-300 relative overflow-hidden group  'text-gray-200 hover:text-white hover:bg-indigo-600/20 sidebar-link w-full">
-                <!-- Icon -->
-                <div class=
-                        "flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-700/30 group-hover:bg-indigo-600/50 transition-all duration-300
-                        {{ $active ? 'bg-indigo-600 text-white' : 'text-indigo-300 group-hover:text-white' }}">
-                            <span class="material-icons group-hover:scale-110 transition-transform duration-300">
-                                {{ $icon }}
-                            </span>
-                        </div>
-
-                        <!-- Label -->
-                        <div class=" sidebar-text ">
-                        <div class="relative z-10  font-medium text-sm
-                        {{ $active ? 'text-2xl font-bold' : 'text-md font-medium' }} transition-all duration-300 group-hover:translate-x-1 rtl:group-hover:-translate-x-1">
-                            {{ $label }}
-                        </div>
-                        </div>
-                        </button>
-            </div>
-        </form>
-    @else
-    <!------------ Only Links without children ----------->
-        <a href="{{ $route }}"
-            class=" flex items-center px-4 py-3 rounded-xl transition-all duration-300 relative overflow-hidden group
-            {{ $active ? 'text-white font-bold bg-indigo-700' : 'text-gray-200 hover:text-white hover:bg-indigo-600/20' }} sidebar-link ">
+<!-- Only For Logout -->
+@if($icon == "logout")
+<form action="/logout" method="POST">
+    @csrf
+    <div>
+        <button
+            type="submit"
+            class=" flex items-center px-4 py-3 rounded-xl transition-all duration-300 relative overflow-hidden group  'text-gray-200 hover:text-white hover:bg-indigo-600/20 sidebar-link w-full">
             <!-- Icon -->
-
-            <div class=
-            "flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-700/30 group-hover:bg-indigo-600/50 transition-all duration-300
-            {{ $active ? 'bg-indigo-600 text-white' : 'text-indigo-300 group-hover:text-white' }}">
+            <div class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-700/30 group-hover:bg-indigo-600/50 transition-all duration-300
+                        {{ $active ? 'bg-indigo-600 text-white' : 'text-indigo-300 group-hover:text-white' }}">
                 <span class="material-icons group-hover:scale-110 transition-transform duration-300">
-                     {{ $icon }}
+                    {{ $icon }}
                 </span>
             </div>
 
             <!-- Label -->
-             <div class=" sidebar-text ">
-             <div class="relative z-10  font-medium text-sm
-            {{ $active ? 'text-2xl font-bold' : 'text-md font-medium' }} transition-all duration-300 group-hover:translate-x-1 rtl:group-hover:-translate-x-1">
-                {{ $label }}
+            <div class=" sidebar-text ">
+                <div class="relative z-10  font-medium text-sm
+                        {{ $active ? 'text-2xl font-bold' : 'text-md font-medium' }} transition-all duration-300 group-hover:translate-x-1 rtl:group-hover:-translate-x-1">
+                    {{ $label }}
+                </div>
             </div>
-             </div>
-        </a>
-    @endif
+        </button>
+    </div>
+</form>
+@else
+<!------------ Only Links without children ----------->
+<a href="{{ $route }}"
+    class=" flex items-center px-4 py-3 rounded-xl transition-all duration-300 relative overflow-hidden group
+            {{ $active ? 'text-white font-bold bg-indigo-700' : 'text-gray-200 hover:text-white hover:bg-indigo-600/20' }} sidebar-link ">
+    <!-- Icon -->
+
+    <div class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-700/30 group-hover:bg-indigo-600/50 transition-all duration-300
+            {{ $active ? 'bg-indigo-600 text-white' : 'text-indigo-300 group-hover:text-white' }}">
+        <span class="material-icons group-hover:scale-110 transition-transform duration-300">
+            {{ $icon }}
+        </span>
+    </div>
+
+    <!-- Label -->
+    <div class=" sidebar-text ">
+        <div class="relative z-10  font-medium text-sm
+            {{ $active ? 'text-2xl font-bold' : 'text-md font-medium' }} transition-all duration-300 group-hover:translate-x-1 rtl:group-hover:-translate-x-1">
+            {{ $label }}
+        </div>
+    </div>
+</a>
+@endif
 @else
 <!----------- Links With Children -------------------------------->
- <div x-data="{ open: false }" class="relative">
+<div x-data="{ open: false }" class="relative">
 
-  <!-- This will be converted to a normal link in case of collapsed sidebar ----------->
+    <!-- This will be converted to a normal link in case of collapsed sidebar ----------->
     <a href="{{ $children[0]['route'] }}"
         class=" hidden items-center px-4 py-3 rounded-xl transition-all duration-300 relative overflow-hidden group
            {{ $active ? 'text-white font-bold bg-indigo-700' : 'text-gray-200 hover:text-white hover:bg-indigo-600/20' }} normalSidbarLink   ">
-           <!-- Icon -->
-           <div class=
-            "flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-700/30 group-hover:bg-indigo-600/50 transition-all duration-300
+        <!-- Icon -->
+        <div class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-700/30 group-hover:bg-indigo-600/50 transition-all duration-300
             {{ $active ? 'bg-indigo-600 text-white' : 'text-indigo-300 group-hover:text-white' }}">
-                <span class="material-icons group-hover:scale-110 transition-transform duration-300">
-                     {{ $icon }}
-                </span>
-            </div>
-         </a>
+            <span class="material-icons group-hover:scale-110 transition-transform duration-300">
+                {{ $icon }}
+            </span>
+        </div>
+    </a>
     <!-- This will be converted to a dropdown link in case of expanded sidebar -->
-        <div class=" dropDownLink ">
-            <button @click="open = !open"
-                class="w-full flex items-center justify-between px-4 py-3 rounded-xl transition-all duration-300 relative overflow-hidden group ">
-                <div class="relative z-10 flex items-center gap-3 flex-1">
+    <div class=" dropDownLink ">
+        <button @click="open = !open"
+            class="w-full flex items-center justify-between px-4 py-3 rounded-xl transition-all duration-300 relative overflow-hidden group ">
+            <div class="relative z-10 flex items-center gap-3 flex-1">
                 <!-- Icon -->
-                    <div class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-700/30 group-hover:bg-indigo-600/50 transition-all duration-300">
-                        <span class="material-icons group-hover:scale-110 transition-transform duration-300">
-                            {{ $icon }}
-                        </span>
-                    </div>
-                    <!-- Label -->
-                    <div class="sidebar-text font-medium text-sm transition-all duration-300 group-hover:translate-x-1">
-                        {{ $label }}
-                    </div>
-                </div>
-
-                <div class="relative z-10 sidebar-text">
-                    <span class="material-icons transform transition-transform duration-300 text-indigo-300 group-hover:text-white"
-                        :class="{ 'rotate-180': open }">
-                        expand_more
+                <div class="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-700/30 group-hover:bg-indigo-600/50 transition-all duration-300">
+                    <span class="material-icons group-hover:scale-110 transition-transform duration-300">
+                        {{ $icon }}
                     </span>
                 </div>
-            </button>
-
-            <div x-show="open"
-                x-transition:enter="transition-all duration-300"
-                x-transition:enter-start="opacity-0 transform translate-y-[-10px]"
-                x-transition:enter-end="opacity-100 transform translate-y-0"
-                class="relative pr-6 rtl:pr-0 rtl:pl-6">
-                <div class="space-y-1 pt-2">
-                    @foreach ($children as $child)
-                        <a href="{{ $child['route'] }}"
-                            class="flex items-center gap-3 px-4 py-2 rounded-xl transition-all duration-300 group relative overflow-hidden hover:bg-indigo-600/20">
-                            <div class="flex items-center justify-center w-7 h-7 rounded-lg bg-indigo-800/30 group-hover:bg-indigo-700/40 transition-all duration-300">
-                                <span class="material-icons text-sm text-indigo-300 group-hover:text-white transition-all duration-300">
-                                    {{ $child['icon'] }}
-                                </span>
-                            </div>
-                            <div class="sidebar-text text-sm text-gray-300 group-hover:text-white transition-colors duration-300">
-                                {{ $child['label'] }}
-                            </div>
-                        </a>
-                    @endforeach
+                <!-- Label -->
+                <div class="sidebar-text font-medium text-sm transition-all duration-300 group-hover:translate-x-1">
+                    {{ $label }}
                 </div>
+            </div>
+
+            <div class="relative z-10 sidebar-text">
+                <span class="material-icons transform transition-transform duration-300 text-indigo-300 group-hover:text-white"
+                    :class="{ 'rotate-180': open }">
+                    expand_more
+                </span>
+            </div>
+        </button>
+
+        <div x-show="open"
+            x-transition:enter="transition-all duration-300"
+            x-transition:enter-start="opacity-0 transform translate-y-[-10px]"
+            x-transition:enter-end="opacity-100 transform translate-y-0"
+            class="relative pr-6 rtl:pr-0 rtl:pl-6">
+            <div class="space-y-1 pt-2">
+                @foreach ($children as $child)
+                <a href="{{ $child['route'] }}"
+                    class="flex items-center gap-3 px-4 py-2 rounded-xl transition-all duration-300 group relative overflow-hidden hover:bg-indigo-600/20">
+                    <div class="flex items-center justify-center w-7 h-7 rounded-lg bg-indigo-800/30 group-hover:bg-indigo-700/40 transition-all duration-300">
+                        <span class="material-icons text-sm text-indigo-300 group-hover:text-white transition-all duration-300">
+                            {{ $child['icon'] }}
+                        </span>
+                    </div>
+                    <div class="sidebar-text text-sm text-gray-300 group-hover:text-white transition-colors duration-300">
+                        {{ $child['label'] }}
+                    </div>
+                </a>
+                @endforeach
             </div>
         </div>
     </div>
+</div>
 @endif

--- a/backend/resources/views/components/layouts/sidebar.blade.php
+++ b/backend/resources/views/components/layouts/sidebar.blade.php
@@ -62,8 +62,8 @@
 
         <x-layouts.sidebar-link :label="'إدارة الاستبيانات'" :icon="'poll'"
             :children="[
-                ['route' => route('surveys.index'), 'label' => 'إضافة استبيان جديد', 'icon' => 'add'],
-                ['route' => route('surveys.index'), 'label' => 'عرض الاستبيانات', 'icon' => 'list_alt'],
+                ['route' => route('youth-surveys.index'), 'label' => 'إستبانات الشباب', 'icon' => 'list_alt'],
+                ['route' => route('company-surveys.index'), 'label' => 'إستبانات الشركات', 'icon' => 'list_alt'],
             ]" />
     </nav>
 

--- a/backend/resources/views/dashboard/company-surveys/index.blade.php
+++ b/backend/resources/views/dashboard/company-surveys/index.blade.php
@@ -1,0 +1,56 @@
+<x-layout title="Company Surveys">
+    <x-common.header title="استبانات الشركات" />
+
+    <x-common.content-container title="جدول الاستبانات">
+        <div class="relative overflow-hidden rounded-xl shadow-lg bg-white">
+            <div class="overflow-x-auto scrollbar-thin scrollbar-thumb-gray-400 scrollbar-track-gray-100">
+                <table class="w-full">
+                    <thead>
+                        <tr class="bg-gradient-to-r from-blue-600 to-blue-700">
+                            <th class="px-4 sm:px-6 py-4 text-start text-sm font-bold text-white whitespace-nowrap">الرقم</th>
+                            <th class="px-4 sm:px-6 py-4 text-start text-sm font-bold text-white whitespace-nowrap">الإسم</th>
+                            <th class="px-4 sm:px-6 py-4 text-start text-sm font-bold text-white whitespace-nowrap">الايميل</th>
+                            <th class="px-4 sm:px-6 py-4 text-start text-sm font-bold text-white whitespace-nowrap">الصناعة</th>
+                            <th class="px-4 sm:px-6 py-4 text-start text-sm font-bold text-white whitespace-nowrap">عدد الموظفين التقريبي</th>
+                            <th class="px-4 sm:px-6 py-4 text-start text-sm font-bold text-white whitespace-nowrap">مرحلة البدء</th>
+                            <th class="px-4 sm:px-6 py-4 text-start text-sm font-bold text-white whitespace-nowrap">التاريخ</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-gray-200">
+                        @foreach ($companyForms as $form)
+                        <tr class="transition-colors hover:bg-gray-50">
+                            <td class="px-4 sm:px-6 py-4 text-sm text-gray-700 whitespace-nowrap">{{ $form->id }}</td>
+                            <td class="px-4 sm:px-6 py-4 text-sm font-medium text-gray-900 whitespace-nowrap">{{ $form->name }}</td>
+                            <td class="px-4 sm:px-6 py-4 text-sm whitespace-nowrap">
+                                <a href="mailto:{{ $form->email }}" class="text-blue-600 hover:text-blue-800 hover:underline">{{ $form->email }}</a>
+                            </td>
+                            <td class="px-4 sm:px-6 py-4 text-sm text-gray-700 whitespace-nowrap">{{ $form->industry }}</td>
+                            <td class="px-4 sm:px-6 py-4 text-sm text-gray-700 whitespace-nowrap">{{ $form->employees }}</td>
+                            <td class="px-4 sm:px-6 py-4 text-sm text-gray-700 whitespace-nowrap">{{ $form->hiring }}</td>
+                            <td class="px-4 sm:px-6 py-4 text-sm whitespace-nowrap">
+                                <span class="inline-flex bg-blue-100 text-blue-800 text-xs font-medium px-2.5 py-0.5 rounded-full">{{ $form->created_at->format('Y-m-d H:i') }}</span>
+                            </td>
+                        </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <!-- Pagination -->
+        <div class="my-5">
+            {{ $companyForms->links('pagination::tailwind') }}
+        </div>
+        <!-- Empty State -->
+        @if($companyForms->isEmpty())
+        <div class="text-center py-12">
+            <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4" />
+            </svg>
+            <h3 class="mt-2 text-sm font-medium text-gray-900">لا توجد بيانات</h3>
+        </div>
+        @endif
+    </x-common.content-container>
+
+
+</x-layout>

--- a/backend/resources/views/dashboard/youth-surveys/index.blade.php
+++ b/backend/resources/views/dashboard/youth-surveys/index.blade.php
@@ -1,0 +1,50 @@
+<x-layout title="Youth Surveys">
+    <x-common.header title="استبانات الشباب" />
+
+    <x-common.content-container title="جدول الاستبانات">
+        <div class="relative overflow-hidden rounded-xl shadow-lg bg-white">
+            <div class="overflow-x-auto scrollbar-thin scrollbar-thumb-gray-400 scrollbar-track-gray-100">
+                <table class="w-full">
+                    <thead>
+                        <tr class="bg-gradient-to-r from-blue-600 to-blue-700">
+                            <th class="px-4 sm:px-6 py-4 text-start text-sm font-bold text-white whitespace-nowrap">الرقم</th>
+                            <th class="px-4 sm:px-6 py-4 text-start text-sm font-bold text-white whitespace-nowrap">الإسم</th>
+                            <th class="px-4 sm:px-6 py-4 text-start text-sm font-bold text-white whitespace-nowrap">المدينة</th>
+                            <th class="px-4 sm:px-6 py-4 text-start text-sm font-bold text-white whitespace-nowrap">العنوان</th>
+                            <th class="px-4 sm:px-6 py-4 text-start text-sm font-bold text-white whitespace-nowrap">تاريخ الميلاد</th>
+                            <th class="px-4 sm:px-6 py-4 text-start text-sm font-bold text-white whitespace-nowrap">أرقام التواصل</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-gray-200">
+                        @foreach ($youthForms as $form)
+                        <tr class="transition-colors hover:bg-gray-50">
+                            <td class="px-4 sm:px-6 py-4 text-sm text-gray-700 whitespace-nowrap">{{ $form->id }}</td>
+                            <td class="px-4 sm:px-6 py-4 text-sm font-medium text-gray-900 whitespace-nowrap">{{ $form->name }}</td>
+                         
+                            <td class="px-4 sm:px-6 py-4 text-sm text-gray-700 whitespace-nowrap">{{ $form->city }}</td>
+                            <td class="px-4 sm:px-6 py-4 text-sm text-gray-700 whitespace-nowrap">{{ $form->address }}</td>
+                            <td class="px-4 sm:px-6 py-4 text-sm text-gray-700 whitespace-nowrap">{{ $form->birth_date ? \Carbon\Carbon::parse($form->birth_date)->format('Y-m-d') : 'N/A' }}</td>
+                            <td class="px-4 sm:px-6 py-4 text-sm text-gray-700 whitespace-nowrap">{{ $form->phone }}</td>
+                        </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <!-- Pagination -->
+        <div class="my-5">
+            {{ $youthForms->links('pagination::tailwind') }}
+        </div>
+        <!-- Empty State -->
+        @if($youthForms->isEmpty())
+        <div class="text-center py-12">
+            <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4" />
+            </svg>
+            <h3 class="mt-2 text-sm font-medium text-gray-900">لا توجد بيانات</h3>
+        </div>
+        @endif
+    </x-common.content-container>
+
+</x-layout>

--- a/backend/resources/views/vendor/pagination/bootstrap-4.blade.php
+++ b/backend/resources/views/vendor/pagination/bootstrap-4.blade.php
@@ -1,0 +1,46 @@
+@if ($paginator->hasPages())
+    <nav>
+        <ul class="pagination">
+            {{-- Previous Page Link --}}
+            @if ($paginator->onFirstPage())
+                <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.previous')">
+                    <span class="page-link" aria-hidden="true">&lsaquo;</span>
+                </li>
+            @else
+                <li class="page-item">
+                    <a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev" aria-label="@lang('pagination.previous')">&lsaquo;</a>
+                </li>
+            @endif
+
+            {{-- Pagination Elements --}}
+            @foreach ($elements as $element)
+                {{-- "Three Dots" Separator --}}
+                @if (is_string($element))
+                    <li class="page-item disabled" aria-disabled="true"><span class="page-link">{{ $element }}</span></li>
+                @endif
+
+                {{-- Array Of Links --}}
+                @if (is_array($element))
+                    @foreach ($element as $page => $url)
+                        @if ($page == $paginator->currentPage())
+                            <li class="page-item active" aria-current="page"><span class="page-link">{{ $page }}</span></li>
+                        @else
+                            <li class="page-item"><a class="page-link" href="{{ $url }}">{{ $page }}</a></li>
+                        @endif
+                    @endforeach
+                @endif
+            @endforeach
+
+            {{-- Next Page Link --}}
+            @if ($paginator->hasMorePages())
+                <li class="page-item">
+                    <a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next" aria-label="@lang('pagination.next')">&rsaquo;</a>
+                </li>
+            @else
+                <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.next')">
+                    <span class="page-link" aria-hidden="true">&rsaquo;</span>
+                </li>
+            @endif
+        </ul>
+    </nav>
+@endif

--- a/backend/resources/views/vendor/pagination/bootstrap-5.blade.php
+++ b/backend/resources/views/vendor/pagination/bootstrap-5.blade.php
@@ -1,0 +1,88 @@
+@if ($paginator->hasPages())
+    <nav class="d-flex justify-items-center justify-content-between">
+        <div class="d-flex justify-content-between flex-fill d-sm-none">
+            <ul class="pagination">
+                {{-- Previous Page Link --}}
+                @if ($paginator->onFirstPage())
+                    <li class="page-item disabled" aria-disabled="true">
+                        <span class="page-link">@lang('pagination.previous')</span>
+                    </li>
+                @else
+                    <li class="page-item">
+                        <a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev">@lang('pagination.previous')</a>
+                    </li>
+                @endif
+
+                {{-- Next Page Link --}}
+                @if ($paginator->hasMorePages())
+                    <li class="page-item">
+                        <a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next">@lang('pagination.next')</a>
+                    </li>
+                @else
+                    <li class="page-item disabled" aria-disabled="true">
+                        <span class="page-link">@lang('pagination.next')</span>
+                    </li>
+                @endif
+            </ul>
+        </div>
+
+        <div class="d-none flex-sm-fill d-sm-flex align-items-sm-center justify-content-sm-between">
+            <div>
+                <p class="small text-muted">
+                    {!! __('Showing') !!}
+                    <span class="fw-semibold">{{ $paginator->firstItem() }}</span>
+                    {!! __('to') !!}
+                    <span class="fw-semibold">{{ $paginator->lastItem() }}</span>
+                    {!! __('of') !!}
+                    <span class="fw-semibold">{{ $paginator->total() }}</span>
+                    {!! __('results') !!}
+                </p>
+            </div>
+
+            <div>
+                <ul class="pagination">
+                    {{-- Previous Page Link --}}
+                    @if ($paginator->onFirstPage())
+                        <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.previous')">
+                            <span class="page-link" aria-hidden="true">&lsaquo;</span>
+                        </li>
+                    @else
+                        <li class="page-item">
+                            <a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev" aria-label="@lang('pagination.previous')">&lsaquo;</a>
+                        </li>
+                    @endif
+
+                    {{-- Pagination Elements --}}
+                    @foreach ($elements as $element)
+                        {{-- "Three Dots" Separator --}}
+                        @if (is_string($element))
+                            <li class="page-item disabled" aria-disabled="true"><span class="page-link">{{ $element }}</span></li>
+                        @endif
+
+                        {{-- Array Of Links --}}
+                        @if (is_array($element))
+                            @foreach ($element as $page => $url)
+                                @if ($page == $paginator->currentPage())
+                                    <li class="page-item active" aria-current="page"><span class="page-link">{{ $page }}</span></li>
+                                @else
+                                    <li class="page-item"><a class="page-link" href="{{ $url }}">{{ $page }}</a></li>
+                                @endif
+                            @endforeach
+                        @endif
+                    @endforeach
+
+                    {{-- Next Page Link --}}
+                    @if ($paginator->hasMorePages())
+                        <li class="page-item">
+                            <a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next" aria-label="@lang('pagination.next')">&rsaquo;</a>
+                        </li>
+                    @else
+                        <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.next')">
+                            <span class="page-link" aria-hidden="true">&rsaquo;</span>
+                        </li>
+                    @endif
+                </ul>
+            </div>
+        </div>
+    </nav>
+@endif

--- a/backend/resources/views/vendor/pagination/default.blade.php
+++ b/backend/resources/views/vendor/pagination/default.blade.php
@@ -1,0 +1,46 @@
+@if ($paginator->hasPages())
+    <nav>
+        <ul class="pagination">
+            {{-- Previous Page Link --}}
+            @if ($paginator->onFirstPage())
+                <li class="disabled" aria-disabled="true" aria-label="@lang('pagination.previous')">
+                    <span aria-hidden="true">&lsaquo;</span>
+                </li>
+            @else
+                <li>
+                    <a href="{{ $paginator->previousPageUrl() }}" rel="prev" aria-label="@lang('pagination.previous')">&lsaquo;</a>
+                </li>
+            @endif
+
+            {{-- Pagination Elements --}}
+            @foreach ($elements as $element)
+                {{-- "Three Dots" Separator --}}
+                @if (is_string($element))
+                    <li class="disabled" aria-disabled="true"><span>{{ $element }}</span></li>
+                @endif
+
+                {{-- Array Of Links --}}
+                @if (is_array($element))
+                    @foreach ($element as $page => $url)
+                        @if ($page == $paginator->currentPage())
+                            <li class="active" aria-current="page"><span>{{ $page }}</span></li>
+                        @else
+                            <li><a href="{{ $url }}">{{ $page }}</a></li>
+                        @endif
+                    @endforeach
+                @endif
+            @endforeach
+
+            {{-- Next Page Link --}}
+            @if ($paginator->hasMorePages())
+                <li>
+                    <a href="{{ $paginator->nextPageUrl() }}" rel="next" aria-label="@lang('pagination.next')">&rsaquo;</a>
+                </li>
+            @else
+                <li class="disabled" aria-disabled="true" aria-label="@lang('pagination.next')">
+                    <span aria-hidden="true">&rsaquo;</span>
+                </li>
+            @endif
+        </ul>
+    </nav>
+@endif

--- a/backend/resources/views/vendor/pagination/semantic-ui.blade.php
+++ b/backend/resources/views/vendor/pagination/semantic-ui.blade.php
@@ -1,0 +1,36 @@
+@if ($paginator->hasPages())
+    <div class="ui pagination menu" role="navigation">
+        {{-- Previous Page Link --}}
+        @if ($paginator->onFirstPage())
+            <a class="icon item disabled" aria-disabled="true" aria-label="@lang('pagination.previous')"> <i class="left chevron icon"></i> </a>
+        @else
+            <a class="icon item" href="{{ $paginator->previousPageUrl() }}" rel="prev" aria-label="@lang('pagination.previous')"> <i class="left chevron icon"></i> </a>
+        @endif
+
+        {{-- Pagination Elements --}}
+        @foreach ($elements as $element)
+            {{-- "Three Dots" Separator --}}
+            @if (is_string($element))
+                <a class="icon item disabled" aria-disabled="true">{{ $element }}</a>
+            @endif
+
+            {{-- Array Of Links --}}
+            @if (is_array($element))
+                @foreach ($element as $page => $url)
+                    @if ($page == $paginator->currentPage())
+                        <a class="item active" href="{{ $url }}" aria-current="page">{{ $page }}</a>
+                    @else
+                        <a class="item" href="{{ $url }}">{{ $page }}</a>
+                    @endif
+                @endforeach
+            @endif
+        @endforeach
+
+        {{-- Next Page Link --}}
+        @if ($paginator->hasMorePages())
+            <a class="icon item" href="{{ $paginator->nextPageUrl() }}" rel="next" aria-label="@lang('pagination.next')"> <i class="right chevron icon"></i> </a>
+        @else
+            <a class="icon item disabled" aria-disabled="true" aria-label="@lang('pagination.next')"> <i class="right chevron icon"></i> </a>
+        @endif
+    </div>
+@endif

--- a/backend/resources/views/vendor/pagination/simple-bootstrap-4.blade.php
+++ b/backend/resources/views/vendor/pagination/simple-bootstrap-4.blade.php
@@ -1,0 +1,27 @@
+@if ($paginator->hasPages())
+    <nav>
+        <ul class="pagination">
+            {{-- Previous Page Link --}}
+            @if ($paginator->onFirstPage())
+                <li class="page-item disabled" aria-disabled="true">
+                    <span class="page-link">@lang('pagination.previous')</span>
+                </li>
+            @else
+                <li class="page-item">
+                    <a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev">@lang('pagination.previous')</a>
+                </li>
+            @endif
+
+            {{-- Next Page Link --}}
+            @if ($paginator->hasMorePages())
+                <li class="page-item">
+                    <a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next">@lang('pagination.next')</a>
+                </li>
+            @else
+                <li class="page-item disabled" aria-disabled="true">
+                    <span class="page-link">@lang('pagination.next')</span>
+                </li>
+            @endif
+        </ul>
+    </nav>
+@endif

--- a/backend/resources/views/vendor/pagination/simple-bootstrap-5.blade.php
+++ b/backend/resources/views/vendor/pagination/simple-bootstrap-5.blade.php
@@ -1,0 +1,29 @@
+@if ($paginator->hasPages())
+    <nav role="navigation" aria-label="Pagination Navigation">
+        <ul class="pagination">
+            {{-- Previous Page Link --}}
+            @if ($paginator->onFirstPage())
+                <li class="page-item disabled" aria-disabled="true">
+                    <span class="page-link">{!! __('pagination.previous') !!}</span>
+                </li>
+            @else
+                <li class="page-item">
+                    <a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev">
+                        {!! __('pagination.previous') !!}
+                    </a>
+                </li>
+            @endif
+
+            {{-- Next Page Link --}}
+            @if ($paginator->hasMorePages())
+                <li class="page-item">
+                    <a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next">{!! __('pagination.next') !!}</a>
+                </li>
+            @else
+                <li class="page-item disabled" aria-disabled="true">
+                    <span class="page-link">{!! __('pagination.next') !!}</span>
+                </li>
+            @endif
+        </ul>
+    </nav>
+@endif

--- a/backend/resources/views/vendor/pagination/simple-default.blade.php
+++ b/backend/resources/views/vendor/pagination/simple-default.blade.php
@@ -1,0 +1,19 @@
+@if ($paginator->hasPages())
+    <nav>
+        <ul class="pagination">
+            {{-- Previous Page Link --}}
+            @if ($paginator->onFirstPage())
+                <li class="disabled" aria-disabled="true"><span>@lang('pagination.previous')</span></li>
+            @else
+                <li><a href="{{ $paginator->previousPageUrl() }}" rel="prev">@lang('pagination.previous')</a></li>
+            @endif
+
+            {{-- Next Page Link --}}
+            @if ($paginator->hasMorePages())
+                <li><a href="{{ $paginator->nextPageUrl() }}" rel="next">@lang('pagination.next')</a></li>
+            @else
+                <li class="disabled" aria-disabled="true"><span>@lang('pagination.next')</span></li>
+            @endif
+        </ul>
+    </nav>
+@endif

--- a/backend/resources/views/vendor/pagination/simple-tailwind.blade.php
+++ b/backend/resources/views/vendor/pagination/simple-tailwind.blade.php
@@ -1,0 +1,25 @@
+@if ($paginator->hasPages())
+    <nav role="navigation" aria-label="Pagination Navigation" class="flex justify-between">
+        {{-- Previous Page Link --}}
+        @if ($paginator->onFirstPage())
+            <span class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 rounded-md dark:text-gray-600 dark:bg-gray-800 dark:border-gray-600">
+                {!! __('pagination.previous') !!}
+            </span>
+        @else
+            <a href="{{ $paginator->previousPageUrl() }}" rel="prev" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-300 dark:focus:border-blue-700 dark:active:bg-gray-700 dark:active:text-gray-300">
+                {!! __('pagination.previous') !!}
+            </a>
+        @endif
+
+        {{-- Next Page Link --}}
+        @if ($paginator->hasMorePages())
+            <a href="{{ $paginator->nextPageUrl() }}" rel="next" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-300 dark:focus:border-blue-700 dark:active:bg-gray-700 dark:active:text-gray-300">
+                {!! __('pagination.next') !!}
+            </a>
+        @else
+            <span class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 rounded-md dark:text-gray-600 dark:bg-gray-800 dark:border-gray-600">
+                {!! __('pagination.next') !!}
+            </span>
+        @endif
+    </nav>
+@endif

--- a/backend/resources/views/vendor/pagination/tailwind.blade.php
+++ b/backend/resources/views/vendor/pagination/tailwind.blade.php
@@ -1,0 +1,109 @@
+@if ($paginator->hasPages())
+<nav role="navigation" aria-label="{{ __('Pagination Navigation') }}" class="flex items-center justify-between">
+    <div class="flex justify-between flex-1 sm:hidden">
+        @if ($paginator->onFirstPage())
+        <span class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 rounded-md dark:text-gray-600 dark:bg-gray-100 dark:border-gray-600">
+            {!! __('pagination.previous') !!}
+        </span>
+        @else
+        <a href="{{ $paginator->previousPageUrl() }}" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150 dark:bg-gray-100 dark:border-gray-600 dark:text-gray-300 dark:focus:border-blue-700 dark:active:bg-gray-700 dark:active:text-gray-300">
+            {!! __('pagination.previous') !!}
+        </a>
+        @endif
+
+        @if ($paginator->hasMorePages())
+        <a href="{{ $paginator->nextPageUrl() }}" class="relative inline-flex items-center px-4 py-2 ml-3 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150 dark:bg-gray-100 dark:border-gray-600 dark:text-gray-300 dark:focus:border-blue-700 dark:active:bg-gray-700 dark:active:text-gray-300">
+            {!! __('pagination.next') !!}
+        </a>
+        @else
+        <span class="relative inline-flex items-center px-4 py-2 ml-3 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 rounded-md dark:text-gray-600 dark:bg-gray-100 dark:border-gray-600">
+            {!! __('pagination.next') !!}
+        </span>
+        @endif
+    </div>
+
+    <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
+        <div>
+            <p class="text-sm text-gray-700 leading-5 dark:text-gray-400">
+                {!! __('Showing') !!}
+                @if ($paginator->firstItem())
+                <span class="font-medium">{{ $paginator->firstItem() }}</span>
+                {!! __('to') !!}
+                <span class="font-medium">{{ $paginator->lastItem() }}</span>
+                @else
+                {{ $paginator->count() }}
+                @endif
+                {!! __('of') !!}
+                <span class="font-medium">{{ $paginator->total() }}</span>
+                {!! __('results') !!}
+            </p>
+        </div>
+
+        <div>
+            <span class="relative z-0 inline-flex rtl:flex-row-reverse shadow-sm rounded-md">
+                {{-- Previous Page Link --}}
+                @if ($paginator->onFirstPage())
+                <span aria-disabled="true" aria-label="{{ __('pagination.previous') }}">
+                    <span class="relative inline-flex items-center px-2 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default rounded-l-md leading-5 dark:bg-gray-100 dark:border-gray-600" aria-hidden="true">
+                        <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                            <path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd" />
+                        </svg>
+                    </span>
+                </span>
+                @else
+                <a href="{{ $paginator->previousPageUrl() }}" rel="prev" class="relative inline-flex items-center px-2 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 rounded-l-md leading-5 hover:text-gray-400 focus:z-10 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-500 transition ease-in-out duration-150 dark:bg-gray-100 dark:border-gray-600 dark:active:bg-gray-700 dark:focus:border-blue-800" aria-label="{{ __('pagination.previous') }}">
+                    <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                        <path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd" />
+                    </svg>
+                </a>
+                @endif
+
+                {{-- Pagination Elements --}}
+                @foreach ($elements as $element)
+                {{-- "Three Dots" Separator --}}
+                @if (is_string($element))
+                <span aria-disabled="true">
+                    <span class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-700 bg-white border border-gray-300 cursor-default leading-5 dark:bg-gray-100 dark:border-gray-600">{{ $element }}</span>
+                </span>
+                @endif
+
+                {{-- Array Of Links --}}
+                @if (is_array($element))
+                    @foreach ($element as $page => $url)
+                        @if ($page == $paginator->currentPage())
+                            <span aria-current="page">
+                                <span class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-white bg-blue-600 border border-blue-600 cursor-default leading-5">
+                                    {{ $page }}
+                                </span>
+                            </span>
+                         @else
+                            <a href="{{ $url }}" class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-blue-600 bg-white border border-gray-300 leading-5 hover:text-blue-500 hover:bg-gray-100 focus:outline-none focus:ring ring-blue-300 focus:border-blue-500 active:bg-gray-100 active:text-blue-700 transition ease-in-out duration-150" aria-label="{{ __('Go to page :page', ['page' => $page]) }}">
+                                {{ $page }}
+                             </a>
+                         @endif
+                    @endforeach
+                @endif
+
+                @endforeach
+
+                {{-- Next Page Link --}}
+                @if ($paginator->hasMorePages())
+                <a href="{{ $paginator->nextPageUrl() }}" rel="next" class="relative inline-flex items-center px-2 py-2 -ml-px text-sm font-medium text-gray-500 bg-white border border-gray-300 rounded-r-md leading-5 hover:text-gray-400 focus:z-10 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-500 transition ease-in-out duration-150 dark:bg-gray-100 dark:border-gray-300 dark:active:bg-gray-100 dark:focus:border-blue-400" aria-label="{{ __('pagination.next') }}">
+                    <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                        <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd" />
+                    </svg>
+                </a>
+                @else
+                <span aria-disabled="true" aria-label="{{ __('pagination.next') }}">
+                    <span class="relative inline-flex items-center px-2 py-2 -ml-px text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default rounded-r-md leading-5 dark:bg-gray-100 dark:border-gray-600" aria-hidden="true">
+                        <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                            <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd" />
+                        </svg>
+                    </span>
+                </span>
+                @endif
+            </span>
+        </div>
+    </div>
+</nav>
+@endif

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -1,7 +1,9 @@
 <?php
 
+use App\Http\Controllers\Dashboard\CompanyFormController;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Dashboard\DashboardSessionController;
+use App\Http\Controllers\Dashboard\YouthFormController;
 
 // Public login routes
 Route::middleware('guest')->group(function () {
@@ -18,7 +20,8 @@ Route::middleware('auth')->group(function () {
     Route::get('/permissions', fn() => 'permissions.index')->name('permissions.index');
     Route::get('/bootcamps', fn() => 'bootcamps.index')->name('bootcamps.index');
     Route::get('/jobs', fn() => 'jobs.index')->name('jobs.index');
-    Route::get('/surveys', fn() => 'surveys.index')->name('surveys.index');
+    Route::get('/youth-surveys', [YouthFormController::class, 'index'])->name('youth-surveys.index');
+    Route::get('/company-surveys', [CompanyFormController::class, 'index'])->name('company-surveys.index');
     Route::get('/users', fn() => view('dashboard.users.index'))->name('users.index');
 });
 


### PR DESCRIPTION
I have created reusable pages for Youth and Company surveys within the dashboard. These pages utilize reusable components for the header and content container, allowing for consistent layout across the dashboard.